### PR TITLE
Prevent message from meta input being overwritten

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -139,7 +139,11 @@ exports.log = function (options) {
 
     output         = exports.clone(meta) || {};
     output.level   = options.level;
-    output.message = options.message;
+    output.message = output.message || '';
+
+    if (options.message) {
+      output.message = options.message;
+    }
 
     if (timestamp) {
       output.timestamp = timestamp;


### PR DESCRIPTION
Creating a log entry with an object with a "message" property, but no explicit message causes the message property of that object to be overwritten. For example, we are trying to log certain error cases with:

```javascript
thing.on('error', function (err) {
    logger.error(err);
});
```

However this caused the message property of the Error to be overwritten with an empty string, which is bad news for our logs since often the most information about the nature of the error is contained within the message.

Instead, only overwrite the message passed as a property of the meta object if a message is explicitly passed as an argument.