### PR TITLE
Added showLevel flag to common.js, file*, memory and console transports.

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,6 +606,7 @@ The Console transport takes a few simple options:
 * __silent:__ Boolean flag indicating whether to suppress output (default false).
 * __colorize:__ Boolean flag indicating if we should colorize output (default false).
 * __timestamp:__ Boolean flag indicating if we should prepend output with timestamps (default false). If function is specified, its return value will be used instead of timestamps.
+* __showLevel:__ Boolean flag indicating if we should prepend output with level (default true).
 
 *Metadata:* Logged via util.inspect(meta);
 
@@ -625,6 +626,7 @@ The File transport should really be the 'Stream' transport since it will accept 
 * __maxFiles:__ Limit the number of files created when the size of the logfile is exceeded.
 * __stream:__ The WriteableStream to write output to.
 * __json:__ If true, messages will be logged as JSON (default true).
+* __showLevel:__ Boolean flag indicating if we should prepend output with level (default true).
 
 *Metadata:* Logged via util.inspect(meta);
 

--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -114,6 +114,7 @@ exports.log = function (options) {
                   ? options.timestamp
                   : exports.timestamp,
       timestamp   = options.timestamp ? timestampFn() : null,
+      showLevel   = options.showLevel === undefined ? true : options.showLevel,
       meta        = options.meta !== undefined || options.meta !== null ? exports.clone(cycle.decycle(options.meta)) : null,
       output;
 
@@ -174,9 +175,9 @@ exports.log = function (options) {
     });
   }
 
-  output = timestamp ? timestamp + ' - ' : '';
-  output += options.colorize ? config.colorize(options.level) : options.level;
-  output += ': ';
+  output = timestamp ? timestamp + (showLevel ? ' - ' : '') : '';
+  output += showLevel ? options.colorize ? config.colorize(options.level) : options.level : '';
+  output += timestamp || showLevel ? ': ' : '';
   output += options.label ? ('[' + options.label + '] ') : '';
   output += options.message;
 

--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -26,6 +26,7 @@ var Console = exports.Console = function (options) {
   this.colorize    = options.colorize    || false;
   this.prettyPrint = options.prettyPrint || false;
   this.timestamp   = typeof options.timestamp !== 'undefined' ? options.timestamp : false;
+  this.showLevel   = options.showLevel === undefined ? true : options.showLevel;
   this.label       = options.label       || null;
 
   if (this.json) {

--- a/lib/winston/transports/daily-rotate-file.js
+++ b/lib/winston/transports/daily-rotate-file.js
@@ -70,6 +70,7 @@ var DailyRotateFile = exports.DailyRotateFile = function (options) {
   this.maxsize     = options.maxsize     || null;
   this.maxFiles    = options.maxFiles    || null;
   this.prettyPrint = options.prettyPrint || false;
+  this.showLevel   = options.showLevel === undefined ? true : options.showLevel;
   this.timestamp   = options.timestamp != null ? options.timestamp : true;
   this.datePattern = options.datePattern != null ? options.datePattern : '.yyyy-MM-dd';
   
@@ -154,7 +155,8 @@ DailyRotateFile.prototype.log = function (level, msg, meta, callback) {
     colorize:    this.colorize,
     prettyPrint: this.prettyPrint,
     timestamp:   this.timestamp,
-    stringify:   this.stringify
+    stringify:   this.stringify,
+    showLevel:   this.showLevel
   }) + '\n';
 
   this._size += output.length;

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -72,6 +72,7 @@ var File = exports.File = function (options) {
   this.prettyPrint = options.prettyPrint || false;
   this.label       = options.label       || null;
   this.timestamp   = options.timestamp != null ? options.timestamp : true;
+  this.showLevel   = options.showLevel === undefined ? true : options.showLevel;
 
   if (this.json) {
     this.stringify = options.stringify;

--- a/lib/winston/transports/memory.js
+++ b/lib/winston/transports/memory.js
@@ -21,6 +21,7 @@ var Memory = exports.Memory = function (options) {
   this.colorize    = options.colorize    || false;
   this.prettyPrint = options.prettyPrint || false;
   this.timestamp   = typeof options.timestamp !== 'undefined' ? options.timestamp : false;
+  this.showLevel   = options.showLevel === undefined ? true : options.showLevel;
   this.label       = options.label       || null;
 
   if (this.json) {


### PR DESCRIPTION
Added a showLevel boolean flag to file, memory and console transports that will suppress level messages in log output.

I have a specific need to output a log format that is not compatible with the log level being prefixed to each line.  