### PR TITLE
Updated default option handling for CLI

### DIFF
--- a/lib/winston/logger.js
+++ b/lib/winston/logger.js
@@ -583,8 +583,8 @@ Logger.prototype.cli = function () {
   config.addColors(config.cli.colors);
 
   if (this.transports.console) {
-    this.transports.console.colorize = true;
-    this.transports.console.timestamp = false;
+    this.transports.console.colorize = this.transports.console.colorize || true;
+    this.transports.console.timestamp = this.transports.console.timestamp || false;
   }
 
   return this;


### PR DESCRIPTION
The defaults were overriding settings specified for colorize and timestamp.  I added a check to see if it's been set, otherwise, default.