### PR TITLE
human readable printing of uncaught exceptions

### DIFF
--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -187,7 +187,6 @@ exports.log = function (options) {
       meta = meta.stack;
     }
 
-
     if (typeof meta !== 'object') {
       output += ' ' + meta;
     }
@@ -197,7 +196,8 @@ exports.log = function (options) {
       } 
       //if meta carries unhandled exception data serialize the stack nicely
       else if (
-        Object.keys(meta).length === 5 
+        options.humanReadableUnhandledException
+        && Object.keys(meta).length === 5 
         && meta.hasOwnProperty('date')
         && meta.hasOwnProperty('process')
         && meta.hasOwnProperty('os')

--- a/lib/winston/common.js
+++ b/lib/winston/common.js
@@ -187,15 +187,32 @@ exports.log = function (options) {
       meta = meta.stack;
     }
 
+
     if (typeof meta !== 'object') {
       output += ' ' + meta;
     }
     else if (Object.keys(meta).length > 0) {
-      output += ' ' + (
-        options.prettyPrint
-          ? ('\n' + util.inspect(meta, false, null, options.colorize))
-          : exports.serialize(meta)
-      );
+      if (options.prettyPrint) {
+        output += ' ' + ('\n' + util.inspect(meta, false, null, options.colorize));
+      } 
+      //if meta carries unhandled exception data serialize the stack nicely
+      else if (
+        Object.keys(meta).length === 5 
+        && meta.hasOwnProperty('date')
+        && meta.hasOwnProperty('process')
+        && meta.hasOwnProperty('os')
+        && meta.hasOwnProperty('trace')
+        && meta.hasOwnProperty('stack')){
+        var stack = meta.stack;
+        delete meta.stack;
+        delete meta.trace;
+        output += ' ' + exports.serialize(meta);
+        output += '\n' + stack.map(function(s){
+          return s + '\n';
+        });
+      } else {
+         output += ' ' + exports.serialize(meta);
+      }
     }
   }
 

--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -73,7 +73,8 @@ Console.prototype.log = function (level, msg, meta, callback) {
     prettyPrint: this.prettyPrint,
     raw:         this.raw,
     label:       this.label,
-    logstash:    this.logstash
+    logstash:    this.logstash,
+    humanReadableUnhandledException: this.humanReadableUnhandledException
   });
 
   if (level === 'error' || level === 'debug') {

--- a/lib/winston/transports/daily-rotate-file.js
+++ b/lib/winston/transports/daily-rotate-file.js
@@ -73,6 +73,7 @@ var DailyRotateFile = exports.DailyRotateFile = function (options) {
   this.prettyPrint = options.prettyPrint || false;
   this.timestamp   = options.timestamp != null ? options.timestamp : true;
   this.datePattern = options.datePattern != null ? options.datePattern : '.yyyy-MM-dd';
+
   
   if (this.json) {
     this.stringify = options.stringify;
@@ -156,7 +157,8 @@ DailyRotateFile.prototype.log = function (level, msg, meta, callback) {
     prettyPrint: this.prettyPrint,
     timestamp:   this.timestamp,
     label:       this.label,
-    stringify:   this.stringify
+    stringify:   this.stringify,
+    humanReadableUnhandledException: this.humanReadableUnhandledException
   }) + '\n';
 
   this._size += output.length;

--- a/lib/winston/transports/daily-rotate-file.js
+++ b/lib/winston/transports/daily-rotate-file.js
@@ -73,7 +73,6 @@ var DailyRotateFile = exports.DailyRotateFile = function (options) {
   this.prettyPrint = options.prettyPrint || false;
   this.timestamp   = options.timestamp != null ? options.timestamp : true;
   this.datePattern = options.datePattern != null ? options.datePattern : '.yyyy-MM-dd';
-
   
   if (this.json) {
     this.stringify = options.stringify;

--- a/lib/winston/transports/file.js
+++ b/lib/winston/transports/file.js
@@ -130,7 +130,8 @@ File.prototype.log = function (level, msg, meta, callback) {
     prettyPrint: this.prettyPrint,
     timestamp:   this.timestamp,
     stringify:   this.stringify,
-    label:       this.label
+    label:       this.label,
+    humanReadableUnhandledException: this.humanReadableUnhandledException
   }) + this.eol;
 
   this._size += output.length;

--- a/lib/winston/transports/memory.js
+++ b/lib/winston/transports/memory.js
@@ -66,7 +66,8 @@ Memory.prototype.log = function (level, msg, meta, callback) {
     timestamp:   this.timestamp,
     prettyPrint: this.prettyPrint,
     raw:         this.raw,
-    label:       this.label
+    label:       this.label,
+    humanReadableUnhandledException: this.humanReadableUnhandledException
   });
 
   if (level === 'error' || level === 'debug') {

--- a/lib/winston/transports/transport.js
+++ b/lib/winston/transports/transport.js
@@ -25,6 +25,7 @@ var Transport = exports.Transport = function (options) {
   this.name             = options.name   || this.name;
 
   this.handleExceptions = options.handleExceptions || false;
+  this.humanReadableUnhandledException = options.humanReadableUnhandledException || false;
 };
 
 //


### PR DESCRIPTION
related to issue #84 

option 'humanReadableUnhandledException' enables nicer printing of the error stack in case of a unhandled exception.

with options is false (default):
```
2014-12-17T09:22:49.509Z - error: uncaughtException: my error date=Wed Dec 17 2014 10:22:49 GMT+0100 (CET), pid=23482, uid=1000, gid=1000, cwd=/home/samz/avuba/winston, execPath=/home/samz/.nvm/v0.10.31/bin/node, version=v0.10.31, argv=[node, /home/samz/avuba/winston/wintest], rss=13991936, heapTotal=9293056, heapUsed=3159968, loadavg=[0.44482421875, 0.50146484375, 0.42724609375], uptime=178087.771779633, trace=[column=7, file=/home/samz/avuba/winston/wintest, function=, line=21, method=null, native=false, column=26, file=module.js, function=Module._compile, line=456, method=_compile, native=false, column=10, file=module.js, function=Object.Module._extensions..js, line=474, method=Module._extensions..js, native=false, column=32, file=module.js, function=Module.load, line=356, method=load, native=false, column=12, file=module.js, function=Function.Module._load, line=312, method=Module._load, native=false, column=10, file=module.js, function=Function.Module.runMain, line=497, method=Module.runMain, native=false, column=16, file=node.js, function=startup, line=119, method=null, native=false, column=3, file=node.js, function=null, line=906, method=null, native=false], stack=[Error: my error,     at Object.<anonymous> (/home/samz/avuba/winston/wintest:21:7),     at Module._compile (module.js:456:26),     at Object.Module._extensions..js (module.js:474:10),     at Module.load (module.js:356:32),     at Function.Module._load (module.js:312:12),     at Function.Module.runMain (module.js:497:10),     at startup (node.js:119:16),     at node.js:906:3]
```

when true:
```
2014-12-17T09:22:54.048Z - error: uncaughtException: my error date=Wed Dec 17 2014 10:22:54 GMT+0100 (CET), pid=23498, uid=1000, gid=1000, cwd=/home/samz/avuba/winston, execPath=/home/samz/.nvm/v0.10.31/bin/node, version=v0.10.31, argv=[node, /home/samz/avuba/winston/wintest], rss=13991936, heapTotal=9293056, heapUsed=3160264, loadavg=[0.5693359375, 0.5263671875, 0.435546875], uptime=178092.310348735
Error: my error
,    at Object.<anonymous> (/home/samz/avuba/winston/wintest:21:7)
,    at Module._compile (module.js:456:26)
,    at Object.Module._extensions..js (module.js:474:10)
,    at Module.load (module.js:356:32)
,    at Function.Module._load (module.js:312:12)
,    at Function.Module.runMain (module.js:497:10)
,    at startup (node.js:119:16)
,    at node.js:906:3

```


code is no exactly beautiful because it checks explicitly that meta contains all the fields extracted by ```exception.getAllInfo```.

feel free to suggest improvements to naming, the if condition and what not